### PR TITLE
Created Session Dumper

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -300,6 +300,9 @@ const (
 	// JSON means JSON serialization format
 	JSON = "json"
 
+	// JSON_EXTENDED means JSON serialization format for full session logs including commands
+	JSON_EXTENDED = "json_extended"
+
 	// YAML means YAML serialization format
 	YAML = "yaml"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2039,6 +2039,33 @@ func PlayFile(ctx context.Context, tarFile io.Reader, sid string) error {
 	return playSession(sessionEvents, stream)
 }
 
+
+// PlayFile plays the recorded session from a tar file
+func PlayFileExtended(ctx context.Context, tarFile io.Reader, sid string) error {
+	var sessionEvents []events.EventFields
+	var stream []byte
+	protoReader := events.NewProtoReader(tarFile)
+	playbackDir, err := os.MkdirTemp("", "playback")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer os.RemoveAll(playbackDir)
+	w, err := events.WriteForSSHPlayback(ctx, session.ID(sid), protoReader, playbackDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	sessionEvents, err = w.SessionEvents()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	stream, err = w.SessionChunks()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return playSessionExtended(sessionEvents, stream)
+}
+
 // SFTP securely copies files between Nodes or SSH servers using SFTP
 func (tc *TeleportClient) SFTP(ctx context.Context, args []string, port int, opts sftp.Options, quiet bool) (err error) {
 	ctx, span := tc.Tracer.Start(
@@ -4638,6 +4665,12 @@ func playSession(sessionEvents []events.EventFields, stream []byte) error {
 	case err := <-errorCh:
 		return trace.Wrap(err)
 	}
+}
+
+func playSessionExtended(sessionEvents []events.EventFields, stream []byte) error {
+	player := newSessionPlayer(sessionEvents, stream, nil)
+	player.playRangeExtended(0,0)
+	return nil
 }
 
 func findActiveDatabases(key *Key) ([]tlsca.RouteToDatabase, error) {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -827,7 +827,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	play.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 	play.Flag("format", defaults.FormatFlagDescription(
 		teleport.PTY, teleport.JSON, teleport.YAML,
-	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, "json_extended")
+	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, teleport.JSON_EXTENDED)
 	play.Arg("session-id", "ID of the session to play").Required().StringVar(&cf.SessionID)
 
 	// scp
@@ -1518,7 +1518,7 @@ func onPlay(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	if format == teleport.PTY {
 		return playSession(cf)
-	} else if format == "json_extended" {
+	} else if format == teleport.JSON_EXTENDED {
 		return playSessionExtended(cf)
 	}
 	return exportSession(cf)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -827,7 +827,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	play.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 	play.Flag("format", defaults.FormatFlagDescription(
 		teleport.PTY, teleport.JSON, teleport.YAML,
-	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML)
+	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, "json_extended")
 	play.Arg("session-id", "ID of the session to play").Required().StringVar(&cf.SessionID)
 
 	// scp
@@ -1515,8 +1515,11 @@ func serializeVersion(format string, proxyVersion string, proxyPublicAddress str
 //
 //	recording by connecting to the Teleport cluster
 func onPlay(cf *CLIConf) error {
-	if format := strings.ToLower(cf.Format); format == teleport.PTY {
+	format := strings.ToLower(cf.Format)
+	if format == teleport.PTY {
 		return playSession(cf)
+	} else if format == "json_extended" {
+		return playSessionExtended(cf)
 	}
 	return exportSession(cf)
 }
@@ -1568,6 +1571,34 @@ func playSession(cf *CLIConf) error {
 		}
 		defer tarFile.Close()
 		if err := client.PlayFile(cf.Context, tarFile, sid); err != nil {
+			return trace.Wrap(err)
+		}
+		return nil
+	}
+	tc, err := makeClient(cf, true)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := tc.Play(cf.Context, cf.Namespace, cf.SessionID); err != nil {
+		if trace.IsNotFound(err) {
+			log.WithError(err).Debug("error playing session")
+			return trace.NotFound("Recording for session %s not found.", cf.SessionID)
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func playSessionExtended(cf *CLIConf) error {
+	isLocalFile := path.Ext(cf.SessionID) == ".tar"
+	if isLocalFile {
+		sid := sessionIDFromPath(cf.SessionID)
+		tarFile, err := os.Open(cf.SessionID)
+		if err != nil {
+			return trace.ConvertSystemError(err)
+		}
+		defer tarFile.Close()
+		if err := client.PlayFileExtended(cf.Context, tarFile, sid); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil


### PR DESCRIPTION
Setup (MacOS):
```
brew install golang jq
```

Build:
```
make build/tsh
```

Parse teleport session:
```
./build/tsh play --format json_extended 0331d770-fb5a-421a-9dab-8c9886a9e090.tar | jq .
```
Produces this output:
```
{
  "session_id": "0331d770-fb5a-421a-9dab-8c9886a9e090",
  "session_output": [
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ ",
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ ",
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ ",
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ pwd",
    "/home/ubuntu",
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ ls -al",
    "total 56",
    "drwxr-xr-x 7 ubuntu ubuntu 4096 Mar  3 22:19 \u001b[0m\u001b[01;34m.\u001b[0m",
    "drwxr-xr-x 3 root   root   4096 Feb 28 22:13 \u001b[01;34m..\u001b[0m",
    "drwxr-xr-x 3 ubuntu ubuntu 4096 Feb 28 22:17 \u001b[01;34m.ansible\u001b[0m",
    "-rw------- 1 ubuntu ubuntu   15 Mar  3 22:19 .bash_history",
    "-rw-r--r-- 1 ubuntu ubuntu  220 Feb 25  2020 .bash_logout",
    "-rw-r--r-- 1 ubuntu ubuntu 3771 Feb 25  2020 .bashrc",
    "drwx------ 2 ubuntu ubuntu 4096 Feb 28 22:13 \u001b[01;34m.cache\u001b[0m",
    "-rw-r--r-- 1 root   root   4328 Feb 23 05:20 \u001b[01;31mcuda-keyring_1.0-1_all.deb\u001b[0m",
    "drwxr-xr-x 4 ubuntu ubuntu 4096 Feb 28 22:28 \u001b[01;34mdatabricks\u001b[0m",
    "drwxr-xr-x 2 ubuntu ubuntu 4096 Feb 28 22:27 \u001b[01;34mgpu\u001b[0m",
    "-rw-r--r-- 1 ubuntu ubuntu 1561 Jun 16  2016 nginx_signing.key",
    "-rw-r--r-- 1 ubuntu ubuntu  807 Feb 25  2020 .profile",
    "drwx------ 2 ubuntu ubuntu 4096 Mar  3 22:18 \u001b[01;34m.ssh\u001b[0m",
    "-rw-r--r-- 1 ubuntu ubuntu    0 Feb 28 22:14 .sudo_as_admin_successful",
    "\u001b]0;ubuntu@teleport-ssh-test: ~\u0007\u001b[01;32mubuntu@teleport-ssh-test\u001b[00m:\u001b[01;34m~\u001b[00m$ ls -al\b\b\b\b\b\b\u001b[K\u0007exit",
    "logout",
    ""
  ],
  "access_requests": [
    "ea41aa17-6f51-4a06-806d-715f4063137e"
  ],
  "addr_remote": "10.200.175.211:8996",
  "cluster_name": "teleport.dev.databricks.com",
  "initial_command": [
    ""
  ],
  "login": "ubuntu",
  "namespace": "default",
  "proto": "ssh",
  "server_hostname": "teleport-ssh-test",
  "server_id": "73debd83-461f-4d70-9835-2039e5d5d011",
  "session_recording": "node",
  "time": "2023-03-03T22:44:18.441Z",
  "user": "developer"
}

```